### PR TITLE
Remove and rotate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.env

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ asgiref==3.4.1
 Django==4.0
 django-cors-headers==3.10.1
 djangorestframework==3.13.1
+python-decouple==3.5
 pytz==2021.3
 sqlparse==0.4.2
 tzdata==2021.5

--- a/todo/settings.py
+++ b/todo/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/4.0/ref/settings/
 """
 
 from pathlib import Path
+from decouple import config
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -20,7 +21,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/4.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-n%-*%a%^m=cy6f%1^)q$&p-+9xw$^%ejo-=0c^4(2l2z)&pwdc'
+SECRET_KEY = config("SECRET_KEY")
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True


### PR DESCRIPTION
The [secret key](https://docs.djangoproject.com/en/4.0/ref/settings/#std:setting-SECRET_KEY) was exposed so I removed it from settings and generated a new one and moved it to an .env file that we will need to share amongst ourselves since this will need to not be pushed to GitHub. It was fine to do this since we aren't running it in prod but we should be careful to not push secrets like that again. I tried to rebase the history to get rid of all traces of it but it wasn't really working so I'm just going to mark it as changed in GitGuardian.